### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "dev", "stable" ]
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/EBISPOT/GrEBI/security/code-scanning/1](https://github.com/EBISPOT/GrEBI/security/code-scanning/1)

Add an explicit workflow-level `permissions` block with the minimum required scope.  
For this workflow, the best non-breaking fix is to set:

- `contents: read`

This supports `actions/checkout@v4` while preventing unnecessary write privileges. Place the block near the top-level keys (e.g., after `on:` and before `jobs:`), so it applies to all jobs unless overridden. No imports, methods, or additional definitions are needed since this is YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
