### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs_pdf.yml
+++ b/.github/workflows/docs_pdf.yml
@@ -11,6 +11,9 @@ on:
       - '.github/workflows/docs_pdf.yml'
   workflow_dispatch: {}
 
+permissions:
+  contents: write
+
 jobs:
   build-docs-pdf:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/EBISPOT/GrEBI/security/code-scanning/2](https://github.com/EBISPOT/GrEBI/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (after `on:` and before `jobs:`), granting only what is needed:

- `contents: write` (required for creating/uploading release assets via `action-gh-release`)
- No extra scopes unless required by other steps.

This is the single best fix because it preserves behavior (release upload still works) while enforcing least privilege explicitly.  
File to edit: `.github/workflows/docs_pdf.yml`  
Region: between lines 12 and 14 (after `workflow_dispatch: {}` and before `jobs:`).  
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
