### PR TITLE
Potential fix for code scanning alert no. 3: Double escaping or unescaping

### DIFF
--- a/webapp/generate_docs_pdf.mjs
+++ b/webapp/generate_docs_pdf.mjs
@@ -415,9 +415,13 @@ async function main() {
         const grammar = Prism.languages[prismLang];
         if (!grammar) return `<pre><code>${code}</code></pre>`;
         // Decode HTML entities that marked escaped
+        // Important: decode '&amp;' last to avoid double-unescaping (e.g. '&amp;lt;' -> '&lt;', not '<')
         const decoded = code
-          .replace(/&amp;/g, "&").replace(/&lt;/g, "<")
-          .replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#39;/g, "'");
+          .replace(/&lt;/g, "<")
+          .replace(/&gt;/g, ">")
+          .replace(/&quot;/g, '"')
+          .replace(/&#39;/g, "'")
+          .replace(/&amp;/g, "&");
         const highlighted = Prism.highlight(decoded, grammar, prismLang);
         return `<pre class="language-${prismLang}"><code class="language-${prismLang}">${highlighted}</code></pre>`;
       }


### PR DESCRIPTION
Potential fix for [https://github.com/EBISPOT/GrEBI/security/code-scanning/3](https://github.com/EBISPOT/GrEBI/security/code-scanning/3)

To fix this safely without changing intended functionality, keep the same entity set but decode `&amp;` **last**. This prevents secondary decoding of entities introduced by the first replacement.

Best concrete fix in `webapp/generate_docs_pdf.mjs` (around lines 418–420): reorder the replacement chain so `&lt;`, `&gt;`, `&quot;`, and `&#39;` are decoded first, and `&amp;` is decoded last. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
