### PR TITLE
perf: stop serving 148MB of graph metadata on every page load

### DIFF
--- a/tests/test_api_snapshots.py
+++ b/tests/test_api_snapshots.py
@@ -88,8 +88,9 @@ def collect_api_snapshot(base_url: str, subgraph: str) -> Dict[str, Any]:
     # Subgraphs list
     snapshot["subgraphs"] = api_get(base_url, "/api/v1/graphs")
 
-    # Subgraph metadata
-    snapshot["subgraph_metadata"] = api_get(base_url, f"/api/v1/graphs/{subgraph}")
+    # Subgraph metadata (full=true, so the snapshot keeps covering the bulk keys
+    # that the default summary response omits)
+    snapshot["subgraph_metadata"] = api_get(base_url, f"/api/v1/graphs/{subgraph}", {"full": "true"})
 
     # Nodes search (first page)
     nodes_resp = api_get(base_url, f"/api/v1/graphs/{subgraph}/nodes", {"size": "100"})

--- a/webapp/grebi_api/src/main/java/uk/ac/ebi/grebi/GrebiApi.java
+++ b/webapp/grebi_api/src/main/java/uk/ac/ebi/grebi/GrebiApi.java
@@ -38,6 +38,19 @@ import uk.ac.ebi.grebi.repo.GrebiMetadataRepo;
 
 public class GrebiApi {
 
+    // Metadata keys omitted from GET /api/v1/graphs/{graph} unless ?full is given.
+    // These are only consumed server side (the /stats endpoint derives its counts
+    // from `edges`) but dwarf everything else: for ebi_monarch_xspecies they are
+    // ~150MB of the 150MB response. Use ?full=true to get them.
+    static final List<String> BULK_METADATA_KEYS = List.of(
+        "embedding_pca_models",
+        "edges",
+        "entity_prop_defs",
+        "entity_props",
+        "edge_prop_defs",
+        "edge_props"
+    );
+
     public static void main(String[] args) throws ParseException, org.apache.commons.cli.ParseException, IOException {
 
         GrebiCypherRepo cypher = null;
@@ -126,6 +139,10 @@ public class GrebiApi {
         Gson gson = new Gson();
         ResourceLimits limits = ResourceLimits.get();
 
+        // Serialized summary metadata per graph; the underlying metadata is loaded
+        // once at startup and never mutated, so this only ever needs building once.
+        final Map<String, String> summaryMetadataJson = new java.util.concurrent.ConcurrentHashMap<>();
+
         GrebiMcpServer mcpServer = new GrebiMcpServer(
             cypher, postgres, metadata, graphs, queryTemplates
         );
@@ -176,9 +193,24 @@ public class GrebiApi {
                 })
                 .get("/api/v1/graphs/{graph}", ctx -> {
                     ctx.contentType("application/json");
-                    var meta = new java.util.LinkedHashMap<>(metadata.getMetadata(ctx.pathParam("graph")));
-                    meta.remove("embedding_pca_models");
-                    ctx.result(gson.toJson(meta));
+                    var graph = ctx.pathParam("graph");
+                    var full = ctx.queryParam("full");
+                    if(full != null && !full.equalsIgnoreCase("false")) {
+                        // Opt-in to the complete metadata. This can be hundreds of MB
+                        // (the `edges` type-pair matrix dominates), so it is serialized
+                        // on demand and never cached.
+                        var meta = new java.util.LinkedHashMap<>(metadata.getMetadata(graph));
+                        meta.remove("embedding_pca_models");
+                        ctx.result(gson.toJson(meta));
+                        return;
+                    }
+                    ctx.result(summaryMetadataJson.computeIfAbsent(graph, g -> {
+                        var meta = new java.util.LinkedHashMap<>(metadata.getMetadata(g));
+                        for(String k : BULK_METADATA_KEYS) {
+                            meta.remove(k);
+                        }
+                        return gson.toJson(meta);
+                    }));
                 })
                 .get("/api/v1/graphs/{graph}/stats", ctx -> {
                     var graph = ctx.pathParam("graph");

--- a/webapp/grebi_ui/Caddyfile
+++ b/webapp/grebi_ui/Caddyfile
@@ -6,6 +6,7 @@
     handle_path {$PUBLIC_URL}* {
         root * /opt/grebi_ui/dist
         try_files {path} /
+        encode zstd gzip
         file_server
     }
 }

--- a/webapp/k8chart/templates/backend_deployment.yaml
+++ b/webapp/k8chart/templates/backend_deployment.yaml
@@ -42,10 +42,10 @@ spec:
           resources:
             requests:
               memory: 8Gi
-              cpu: 0.5
+              cpu: {{ .Values.backend.cpu }}
             limits:
               memory: 8Gi
-              cpu: 0.5
+              cpu: {{ .Values.backend.cpu }}
           envFrom:
             - secretRef:
                 name: {{ $postgresSecretName }}
@@ -54,8 +54,11 @@ spec:
               value: http://{{ .Release.Name }}-cypher-service:8085
             - name: GREBI_CONTEXT_PATH
               value: {{ .Values.contextPath }}
+            # UseG1GC is set explicitly: the JVM only auto-selects it when it sees
+            # >=2 CPUs, so a low cpu limit silently drops it to SerialGC, whose
+            # full collections stop the whole API for seconds on this heap size.
             - name: JDK_JAVA_OPTIONS
-              value: "-XX:InitialRAMPercentage=60.0 -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0"
+              value: "-XX:InitialRAMPercentage=60.0 -XX:MinRAMPercentage=60.0 -XX:MaxRAMPercentage=80.0 -XX:+UseG1GC"
             - name: GREBI_QUERY_TEMPLATES_PATH
               value: /data_import/query_templates
             - name: GREBI_EMBEDDING_SERVICE_URL

--- a/webapp/k8chart/values.yaml
+++ b/webapp/k8chart/values.yaml
@@ -44,6 +44,12 @@ apiUrl: "https://wwwdev.ebi.ac.uk/grebi/"
 # works for dev; prod overrides this with the cross-namespace cluster FQDN.
 embeddingServiceUrl: "http://spot-embedding-service:5000/spot/embed"
 
+# API backend CPU (request and limit are set to the same value). Needs to be >=2
+# so the JVM doesn't fall back to a single-threaded GC; see the UseG1GC note in
+# templates/backend_deployment.yaml.
+backend:
+  cpu: 2
+
 postgres:
   secret:
     name: ""


### PR DESCRIPTION
Fixes the slowness on https://www.ebi.ac.uk/spot/grebi. Three compounding problems, all measured against prod.

## 1. `/api/v1/graphs/{graph}` returns 148 MB

| key | bytes |
|---|---|
| `edges` | **149,419,864** |
| everything else combined | ~700,000 |

`edges` is the source-type × edge-type × target-type count matrix. The UI fetches this endpoint on the home, graphs and datasources pages and reads exactly three fields from it — `subgraph_config`, `subgraph_name`, `materialised_queries`. `edges` is only ever used server side, by `/stats`.

`EbiHomePage.tsx:140` pulls it for every graph just to render a display name; `EbiGraphPage.tsx:54` blocks its whole render on it.

Now returns summary metadata by default — **148,518,988 → 158,476 bytes** (21.9 KB gzipped) — from a cached pre-serialized string, since the metadata is loaded once at startup and never mutated. `?full=true` still returns everything for API consumers.

## 2. The backend was on SerialGC

```
-XX:+UseSerialGC   # auto-selected, not configured
```

The JVM only picks G1 when it sees ≥2 CPUs. At `cpu: 500m` it sees 1, so an 8 Gi / 6.4 GB-heap service was running the single-threaded collector. From the pod's perf counters:

| | collections | total | avg pause |
|---|---|---|---|
| young | 34 | 12.4 s | 365 ms |
| full | 6 | 14.9 s | **2.48 s** |

One replica, so every full GC froze the API for everyone. Serializing 148 MB per request (~300 MB of transient UTF-16) is what drove it — live heap is only ~1 GB.

Measured contention, before:

| | idle | during 4 concurrent metadata fetches |
|---|---|---|
| `/suggest` | 45 ms | **859 ms** |
| `/search` | 340 ms | **5.0 s** |

`UseG1GC` is now set explicitly so the collector no longer depends on the CPU-count heuristic, and the backend goes to 2 CPUs via a new `backend.cpu` value. I checked node headroom first — the backend's node is at 21% of 8 cores, and every worker except 2 and 9 has room.

## 3. Static assets served uncompressed

The Caddyfile had no `encode` directive, so `bundle.js` went out as **6.28 MB uncompressed**. gzip → 1.33 MB, zstd → 1.06 MB.

## Notes

- `tests/test_api_snapshots.py` now requests `?full=true` so the snapshots keep covering the bulk metadata keys.
- `mvn compile` and `helm template` both pass.
- The summary response uses a denylist of the bulk keys rather than an allowlist of the three the UI needs, to break external API consumers as little as possible. It is still a public API shape change, hence `?full=true`.
- Worth verifying on dev before triggering the prod `helm-install`. The CPU bump alone will recreate the backend pod.

Not addressed here: the prod cypher-service is cold (4.6 Gi against an 11 GB configured page cache), and the frontend runs `npm run build` in its entrypoint so every pod restart rebuilds the React app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)