### PR TITLE
build: repin owlmake to v0.1.0 to unblock image publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,15 +88,15 @@ RUN mvn -B clean package -DskipTests
 # ---- owlmake `om` binary (the ubergraph builder, used by build_ubergraph.nf) ----
 # Downloaded as a release binary from owlmake's GitHub releases (a portable glibc
 # binary that runs on the UBI9 runtime) — no owlmake build needed. Pinned to a
-# tag for reproducible builds; v0.3.0 is the first release with
-# `om ubergraph --graph-prefix`. Override with --build-arg OWLMAKE_RELEASE=vX.Y.Z
-# (or =latest).
+# tag for reproducible builds; the pinned release must support the flags
+# build_ubergraph.nf passes (-i, --graph-prefix, --offline, -o). Override with
+# --build-arg OWLMAKE_RELEASE=vX.Y.Z (or =latest).
 #
 # Arch: `dpkg --print-architecture` is the build/target arch (amd64|arm64) and
 # the release ships per-arch assets, so each per-arch GrEBI build fetches the
 # matching `om`.
 FROM rust:1.90.0-bullseye AS om-dl
-ARG OWLMAKE_RELEASE=v0.4.0
+ARG OWLMAKE_RELEASE=v0.1.0
 RUN arch="$(dpkg --print-architecture)"; base="https://github.com/EBISPOT/owlmake/releases"; \
     if [ "$OWLMAKE_RELEASE" = "latest" ]; then url="$base/latest/download/om-linux-$arch"; \
     else url="$base/download/$OWLMAKE_RELEASE/om-linux-$arch"; fi; \


### PR DESCRIPTION
The combined image pinned `OWLMAKE_RELEASE=v0.4.0`, which no longer exists after owlmake restarted its version numbering, so the `om` download 404s and the combined build fails.

That broke more than the combined image. The `merge` job that assembles the multi-arch manifests and moves the `:dev` / `:<sha>` tags declares `needs: build`, and `combined` is a leg of that same `build` matrix — so a combined failure skips `merge` for `api`, `ui` and `cypher` too. All three build fine and get discarded. The E2E workflow builds the combined image as well, so it dies before running a single test.

Net effect: nothing has published from `dev` since 2026-08-17. `ghcr.io/ebispot/grebi_api:dev` still points at `sha256:abd7344…`, which is exactly what prod is running, and `grebi_api:6bb0dc9…` (the perf fix from #51) 404s.

Repinned to `v0.1.0`. I checked the binary rather than the version number — it supports every flag `build_ubergraph.nf:76` passes:

```
-i, --input          ✓
--graph-prefix       ✓
--offline            ✓
-o, --output-dir     ✓
```

and both `om-linux-amd64` (44 MB) and `om-linux-arm64` (38 MB) assets return 200.

Once this lands, the merge jobs should publish `api`/`ui`/`cypher` for both this commit and the #51 perf work, and E2E should actually run — including the `?full=true` snapshot change from #51, which has never been exercised.

Separately worth considering (not in this PR): `merge` being gated on the whole `build` matrix means any one broken image blocks publishing all four. Giving `combined` its own job would contain that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)